### PR TITLE
Warning: in_array() expects array in api/Contacts/Sql.php

### DIFF
--- a/inc/class.tracker_bo.inc.php
+++ b/inc/class.tracker_bo.inc.php
@@ -2107,7 +2107,7 @@ class tracker_bo extends tracker_so
 			// find the addressbookentry to link with
 			$addressbook = new Api\Contacts();
 			$contacts = array();
-			$filter['owner'] = 0;
+			$filter['owner'] = array();
 			foreach ($emails as $mailadr)
 			{
 				$contacts = array_merge($contacts,(array)$addressbook->search(
@@ -2169,7 +2169,7 @@ class tracker_bo extends tracker_so
 			// find the addressbookentry to idetify the reply creator
 			$addressbook = new Api\Contacts();
 			$contacts = array();
-			$filter['owner'] = 0;
+			$filter['owner'] = array();
 			foreach ($emails as $mailadr)
 			{
 				$contacts = array_merge($contacts,(array)$addressbook->search(


### PR DESCRIPTION
I change $filter['owner'] assign from 0 to empty array because  method search in EGroupware\Api\Contacts\Sql in line 530 execute in_array on this.

Stack trace:
PHP Warning: in_array() expects parameter 2 to be array, integer given in api/src/Contacts/Sql.php on line 530
#1 api/src/Contacts/Sql.php(530): in_array('5', 0)
#2 api/src/Contacts/Storage.php(741): EGroupware\Api\Contacts\Sql->search(Array, 'contact_id,cont...', '', '', '', false, 'OR', false, Array, '', false, false)
#3 tracker/inc/class.tracker_bo.inc.php(2161): EGroupware\Api\Contacts\Storage->search(Array, 'contact_id,cont...', '', '', '', false, 'OR', false, Array, '', false)
#4 tracker/inc/class.tracker_mailhandler.inc.php(678): tracker_bo->prepare_import_mail('T J...', 'Re: Zg\xC5\x82oszenia...', '<html>\r\n  <head...', Array, 0, 0)
#5 tracker/inc/class.tracker_mailhandler.inc.php(358): tracker_mailhandler->process_message2(Object(EGroupware\Api\Mail), 769, 'INBOX', 0)
#6 api/src/loader/deprecated_factory.php(179): tracker_mailhandler->check_mail(0)
#7 api/src/Asyncservice.php(508): ExecMethod(Array, Array)
#8 api/asyncservices.php(76): EGroupware\Api\Asyncservice->check_run('crontab')
#9 {main}